### PR TITLE
fix: value helper arguments

### DIFF
--- a/src/helpers/input.php
+++ b/src/helpers/input.php
@@ -124,11 +124,11 @@ if (!function_exists('value')) {
     /**
      * Return the default value of the given value.
      *
-     * @param  mixed $value
+     * @param  mixed  $value
      * @return mixed
      */
-    function value($value)
+    function value($value, ...$args)
     {
-        return $value instanceof Closure ? $value() : $value;
+        return $value instanceof Closure ? $value(...$args) : $value;
     }
 }


### PR DESCRIPTION
Hello 👋

This PR fixes a conflict in the `value` helper introduced in [Laravel 8.32.0](https://github.com/laravel/framework/pull/36506). Laravel and other 3rd party packages now expect this helper to accept callback arguments and break when this utility package is loaded.

In my case, I ended up here coming from `paytic/omnipay-euplatesc`.