### PR TITLE
fix: dependencies version conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "php": "^7.4|^8.0",
     "nesbot/carbon": "^2.0",
     "ramsey/uuid": "^3.7|^4.0",
-    "voku/portable-ascii": "^1.4",
+    "voku/portable-ascii": "^1.4|^2.0",
     "league/iso3166": "^3.0"
   },
   "require-dev": {


### PR DESCRIPTION
Hello din nou,

This PR allows the installation of `voku/portable-ascii ^2.0`, required by Laravel 9.

```
- laravel/framework[v9.11.0, ..., 9.x-dev] require voku/portable-ascii ^2.0 -> satisfiable by voku/portable-ascii[2.0.0, 2.0.1].
- You can only install one version of a package, so only one of these can be installed: voku/portable-ascii[1.4.8, ..., 1.6.1, 2.0.0, 2.0.1].
- bytic/utility 1.0.55 requires voku/portable-ascii ^1.4 -> satisfiable by voku/portable-ascii[1.4.0, ..., 1.6.1].
```

Currently stuck on `v1.0.47` because of it.

Thanks!